### PR TITLE
Added annotations to ensure correct deserialization of ErrorMessage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>cz.jirutka.spring</groupId>
     <artifactId>spring-rest-exception-handler</artifactId>
-    <version>1.0.2</version>
+    <version>1.0.2-json</version>
     <packaging>jar</packaging>
 
     <name>Spring REST Exception Handler</name>

--- a/src/main/java/cz/jirutka/spring/exhandler/messages/ErrorMessage.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/messages/ErrorMessage.java
@@ -15,8 +15,10 @@
  */
 package cz.jirutka.spring.exhandler.messages;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
@@ -84,10 +86,12 @@ public class ErrorMessage implements Serializable {
     }
 
 
+    @JsonProperty
     public void setStatus(Integer status) {
         this.status = status;
     }
 
+    @JsonIgnore
     public void setStatus(HttpStatus status) {
         this.status = status.value();
     }

--- a/src/main/java/cz/jirutka/spring/exhandler/messages/ErrorMessage.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/messages/ErrorMessage.java
@@ -15,7 +15,6 @@
  */
 package cz.jirutka.spring.exhandler.messages;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -91,7 +90,6 @@ public class ErrorMessage implements Serializable {
         this.status = status;
     }
 
-    @JsonIgnore
     public void setStatus(HttpStatus status) {
         this.status = status.value();
     }

--- a/src/test/groovy/cz/jirutka/spring/exhandler/messages/ErrorMessageTest.groovy
+++ b/src/test/groovy/cz/jirutka/spring/exhandler/messages/ErrorMessageTest.groovy
@@ -43,4 +43,24 @@ class ErrorMessageTest extends Specification {
                 ! instance
             }
     }
+
+    def 'convert from JSON using Jackson2'() {
+        given:
+        def json = """{
+                "type": "http://httpstatus.es/500",
+                "title": "Title",
+                "status": 500,
+                "detail": "Detail",
+                "instance": "http://httpstatus.es/500"}"""
+        when:
+        def result = jackson.readValue(json, ErrorMessage.class)
+        then:
+        with (jsonParser.parseText(json)) {
+            type == result.type.toString()
+            title == result.title
+            status == result.status
+            detail == result.detail
+            instance == result.instance.toString()
+        }
+    }
 }


### PR DESCRIPTION
Jackson's [POJOPropertyBuilder](https://github.com/FasterXML/jackson-databind/blob/master/src/main/java/com/fasterxml/jackson/databind/introspect/POJOPropertyBuilder.java) will fail to analyze *ErrorMessage* due to the additional setter *setStatus(HttpStatus)*. Added annotations to help the builder.