### PR TITLE
Spring MVC 4.2.0 compatibility

### DIFF
--- a/CHANGELOG.adoc
+++ b/CHANGELOG.adoc
@@ -2,6 +2,10 @@
 :repo-uri: https://github.com/jirutka/spring-rest-exception-handler
 :issue-uri: {repo-uri}/issues
 
+== 1.1.1 (2015-07-27)
+
+* Adds compatibility with Spring MVC 4.2.0.
+
 == 1.1.0 (2015-06-25)
 
 * Include fields from `ErrorMessage` in `ValidationErrorMessage#toString()`.

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 
     <groupId>cz.jirutka.spring</groupId>
     <artifactId>spring-rest-exception-handler</artifactId>
-    <version>1.1.0</version>
+    <version>1.1.1-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Spring REST Exception Handler</name>

--- a/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolver.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolver.java
@@ -140,7 +140,7 @@ public class RestHandlerExceptionResolver extends AbstractHandlerExceptionResolv
 
         ModelAndViewContainer mavContainer = new ModelAndViewContainer();
         MethodParameter returnType = null;
-        if (handler instanceof HandlerMethod) {
+        if (handler != null && handler instanceof HandlerMethod) {
             returnType = ((HandlerMethod) handler).getReturnType();
         }
         try {


### PR DESCRIPTION
The returnType parameter is no longer ignored in Spring MVC 4.2.0, and the current implementation causes a `NullPointerException` when using this version of Spring MVC (tested with 4.2.0.RC2).

See https://github.com/spring-projects/spring-framework/commit/289f35da3a57bb5e491b30c7351072b4e801c519#diff-24571dc5c7743b2a69f7a5df4f2109b2R215

This pull request fixes this issue by using the return type from the handler method instead of `null`. If `handler` is `null` or not an instance of `HandlerMethod`, the code will behave as it did previously.