### PR TITLE
Make ValidationErrorMessage.Error class public

### DIFF
--- a/src/main/java/cz/jirutka/spring/exhandler/messages/ValidationErrorMessage.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/messages/ValidationErrorMessage.java
@@ -60,7 +60,7 @@ public class ValidationErrorMessage extends ErrorMessage {
 
     @Data
     @JsonInclude(NON_EMPTY)
-    static class Error {
+    public static class Error {
         private final String field;
         private final Object rejected;
         private final String message;


### PR DESCRIPTION
This change allows to use inner `ValidationErrorMessage.Error` class e.g. to marshall an endpoint response into this error message.