### PR TITLE
make compatible with Spring 5

### DIFF
--- a/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
@@ -232,7 +232,10 @@ public class RestHandlerExceptionResolverBuilder {
 
         Map<Class, RestExceptionHandler> map = new HashMap<>();
 
-        map.put( NoSuchRequestHandlingMethodException.class, new NoSuchRequestHandlingMethodExceptionHandler() );
+        // this class does not exist in Spring 5
+        if (ClassUtils.isPresent("org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException", getClass().getClassLoader())) {
+            map.put( NoSuchRequestHandlingMethodException.class, new NoSuchRequestHandlingMethodExceptionHandler() );
+        }
         map.put( HttpRequestMethodNotSupportedException.class, new HttpRequestMethodNotSupportedExceptionHandler() );
         map.put( HttpMediaTypeNotSupportedException.class, new HttpMediaTypeNotSupportedExceptionHandler() );
         map.put( MethodArgumentNotValidException.class, new MethodArgumentNotValidExceptionHandler() );

--- a/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
@@ -233,7 +233,9 @@ public class RestHandlerExceptionResolverBuilder {
         Map<Class, RestExceptionHandler> map = new HashMap<>();
 
         // this class does not exist in Spring 5
-        if (ClassUtils.isPresent("org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException", getClass().getClassLoader())) {
+        if (ClassUtils.isPresent(
+		    "org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException",
+			getClass().getClassLoader())) {
             map.put( NoSuchRequestHandlingMethodException.class, new NoSuchRequestHandlingMethodExceptionHandler() );
         }
         map.put( HttpRequestMethodNotSupportedException.class, new HttpRequestMethodNotSupportedExceptionHandler() );

--- a/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
+++ b/src/main/java/cz/jirutka/spring/exhandler/RestHandlerExceptionResolverBuilder.java
@@ -234,8 +234,8 @@ public class RestHandlerExceptionResolverBuilder {
 
         // this class does not exist in Spring 5
         if (ClassUtils.isPresent(
-		    "org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException",
-			getClass().getClassLoader())) {
+            "org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException",
+            getClass().getClassLoader())) {
             map.put( NoSuchRequestHandlingMethodException.class, new NoSuchRequestHandlingMethodExceptionHandler() );
         }
         map.put( HttpRequestMethodNotSupportedException.class, new HttpRequestMethodNotSupportedExceptionHandler() );


### PR DESCRIPTION
Hello!

Great job on the Spring REST Exception handler!
Spring has moved on, and they [removed](https://stackoverflow.com/questions/45076007/what-is-the-replacement-for-springs-deprecated-nosuchrequesthandlingmethodexcep) `org.springframework.web.servlet.mvc.multiaction.NoSuchRequestHandlingMethodException` in Spring 5: 

This pull request makes the library compatible again with Spring 5. A merge and a new release (1.2.1?) would be highly appreciated!
 
Kind regards,
Jan
